### PR TITLE
Fix module resolution

### DIFF
--- a/sample.p5/webpack.config.js
+++ b/sample.p5/webpack.config.js
@@ -6,5 +6,8 @@ module.exports = {
   output: {
     filename: 'bundle.js',
     path: path.join(__dirname, 'public/js')
+  },
+  resolve: {
+    symlinks: false
   }
 };


### PR DESCRIPTION
Add `resolve.symlinks` to fix module resolution failure.

see:
- https://stackoverflow.com/questions/37769228/npm-link-with-webpack-cannot-find-module/48582767
- https://webpack.js.org/configuration/resolve/#resolvesymlinks